### PR TITLE
Fix message counting to only count assistant messages

### DIFF
--- a/backend/internal/services/session_activity_detector.go
+++ b/backend/internal/services/session_activity_detector.go
@@ -273,7 +273,10 @@ func (s *SessionActivityDetector) analyzeMessagePattern(sessionID string) (*Sess
 			continue
 		}
 
-		pattern.MessageCount++
+		// Only count assistant messages for consistency with token calculation
+		if msgRole.Valid && msgRole.String == "assistant" {
+			pattern.MessageCount++
+		}
 
 		// Set last message info
 		if pattern.LastMessageType == nil && msgType.Valid {

--- a/backend/internal/services/session_activity_detector_test.go
+++ b/backend/internal/services/session_activity_detector_test.go
@@ -170,8 +170,8 @@ func TestAnalyzeMessagePattern(t *testing.T) {
 	}
 
 	// Verify pattern analysis
-	if pattern.MessageCount != 5 {
-		t.Errorf("Expected message count 5, got %d", pattern.MessageCount)
+	if pattern.MessageCount != 2 {
+		t.Errorf("Expected message count 2 (assistant messages only), got %d", pattern.MessageCount)
 	}
 
 	if pattern.LastMessageType == nil || *pattern.LastMessageType != "text" {

--- a/backend/internal/services/session_window_service.go
+++ b/backend/internal/services/session_window_service.go
@@ -326,7 +326,8 @@ func (s *SessionWindowService) UpdateWindowStats(windowID string) error {
 			message_count = (
 				SELECT COUNT(*) 
 				FROM messages 
-				WHERE timestamp >= ? AND timestamp < ?
+				WHERE timestamp >= ? AND timestamp < ? 
+				AND message_role = 'assistant'
 			),
 			session_count = (
 				SELECT COUNT(DISTINCT session_id) 

--- a/backend/internal/services/token_service.go
+++ b/backend/internal/services/token_service.go
@@ -238,7 +238,7 @@ func (s *TokenService) UpdateSessionTokens(sessionID string) error {
 			message_count = (
 				SELECT COUNT(*) 
 				FROM messages 
-				WHERE session_id = ?
+				WHERE session_id = ? AND message_role = 'assistant'
 			),
 			end_time = (
 				SELECT MAX(timestamp) FROM messages WHERE session_id = ?

--- a/backend/internal/services/token_service_test.go
+++ b/backend/internal/services/token_service_test.go
@@ -356,7 +356,7 @@ func TestUpdateSessionTokens(t *testing.T) {
 	expectedInputTokens := 0   // User messages are not counted
 	expectedOutputTokens := 500 // 200 + 300 from assistant messages
 	expectedTotalTokens := 500
-	expectedMessageCount := 4   // All messages are counted
+	expectedMessageCount := 2   // Only assistant messages are counted
 
 	if totalInputTokens != expectedInputTokens {
 		t.Errorf("Expected total input tokens %d, got %d", expectedInputTokens, totalInputTokens)


### PR DESCRIPTION
This fixes the issue where Claudeee was showing ~2x higher values than Claude-Usage-Monitor. The root cause was that Claudeee was counting all messages while Claude-Usage-Monitor counts only assistant messages.

Changes:
- Updated SessionWindowService to filter message counts by message_role = 'assistant'
- Updated TokenService to count only assistant messages in sessions
- Updated SessionActivityDetector to count only assistant messages for consistency
- Updated test cases to expect correct assistant-only message counts

This brings Claudeee's metrics in line with Claude-Usage-Monitor's counting methodology.

🤖 Generated with [Claude Code](https://claude.ai/code)