### PR TITLE
Fix job execution TTY and permission issues

### DIFF
--- a/frontend/components/job-history.tsx
+++ b/frontend/components/job-history.tsx
@@ -206,7 +206,7 @@ export function JobHistory({ onJobSelect, refreshTrigger }: JobHistoryProps) {
                     読み込み中...
                   </TableCell>
                 </TableRow>
-              ) : jobs.length === 0 ? (
+              ) : !jobs || jobs.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
                     ジョブが見つかりません
@@ -281,7 +281,7 @@ export function JobHistory({ onJobSelect, refreshTrigger }: JobHistoryProps) {
         </div>
 
         {/* Pagination Info */}
-        {jobs.length > 0 && (
+        {jobs && jobs.length > 0 && (
           <div className="mt-4 text-sm text-muted-foreground">
             {jobs.length} 件のジョブを表示
           </div>


### PR DESCRIPTION
## Summary
- Resolve job execution failures when backend is started by users instead of Claude Code environment
- Fix TTY conflicts that caused claude processes to hang in stopped state
- Improve error handling and null safety in job history component

## Changes Made
### Backend (job_executor.go)
- **Use `--print` flag**: Changed from `-p` to `--print` for claude command non-interactive mode
- **Environment variables**: Automatically set `CLAUDECODE=1` and `CLAUDE_CODE_ENTRYPOINT=cli` 
- **TTY isolation**: Use `Setsid: true` to create new session and detach from controlling terminal
- **Remove `Setpgid`**: Prevents "operation not permitted" errors

### Frontend (job-history.tsx)
- **Null safety**: Add proper null checks for jobs array to prevent runtime errors
- **Consistent rendering**: Handle both null and empty job arrays gracefully

## Test Plan
- [x] Test job execution from user-started backend process
- [x] Test job execution from Claude Code-started backend process  
- [x] Verify jobs complete successfully with exit code 0
- [x] Confirm no more "T" (stopped) process states
- [x] Test frontend job history displays correctly

## Technical Details
The core issue was that `claude` commands executed from non-interactive contexts would get stopped by TTY signals. By using `Setsid: true`, we create a new session that is completely detached from the controlling terminal, allowing the process to run without TTY interference.

🤖 Generated with [Claude Code](https://claude.ai/code)