### PR TITLE
fix: Add X-API-Key to CORS allowed headers

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -215,7 +215,7 @@ func main() {
 					c.Header("Access-Control-Allow-Origin", origin)
 					c.Header("Access-Control-Allow-Credentials", "true")
 					c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH")
-					c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization, X-Requested-With, DNT, User-Agent, If-Modified-Since, Cache-Control, Range")
+					c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization, X-Requested-With, DNT, User-Agent, If-Modified-Since, Cache-Control, Range, X-API-Key")
 					c.Header("Access-Control-Max-Age", "86400")
 					c.AbortWithStatus(204)
 					return


### PR DESCRIPTION
## Summary
• Fixes CORS preflight error when frontend sends requests with x-api-key header
• Adds X-API-Key to Access-Control-Allow-Headers in backend CORS configuration
• Enables proper frontend-backend authentication

## Test plan
- [x] Restart backend server
- [x] Verify frontend can make authenticated API requests without CORS errors
- [x] Test token usage API endpoint functionality

🤖 Generated with [Claude Code](https://claude.ai/code)